### PR TITLE
Badge to show you’re free of known vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![dependencies][next-update-dependencies-image] ][next-update-dependencies-url]
 [![devdependencies][next-update-devdependencies-image] ][next-update-devdependencies-url]
 [![semantic-release][semantic-image] ][semantic-url]
+[![Known Vulnerabilities](https://snyk.io/test/github/bahmutov/next-update/230d136b5c68dadb1fd5459619df8f7678d28429/badge.svg)](https://snyk.io/test/github/bahmutov/next-update/230d136b5c68dadb1fd5459619df8f7678d28429)
 
 [next-update-icon]: https://nodei.co/npm/next-update.svg?downloads=true
 [next-update-url]: https://npmjs.org/package/next-update


### PR DESCRIPTION
next-update has no vulnerabilities, which is awesome! 

This PR adds a badge that shows you’re free of known vulnerabilities. Note that the badge works off the latest master branch.

Adding the badge will show others that you care about security, and that they should care, too. 
(It will also help to spread the word about Snyk, which would benefit us a lot!). 
 
Check our [documentation](https://snyk.io/docs/badges/#github-badge) if you’d like to know more about our badges. 

Stay secure, 
The Snyk team